### PR TITLE
Enhanced:分隔设置常规模式和源代码文本选中的颜色

### DIFF
--- a/jiaran-card.css
+++ b/jiaran-card.css
@@ -15,11 +15,12 @@
   --color-8-trans: #de729285;
   --color-9: #e99eb4;
   --color-10: #fbd3ea85;
+  --color-11: #B5D6FC;
 
   --background-img: url("./jiaran/diana.png");
 
   --control-text-color: #777;
-  --select-text-bg-color: var(--color-3);
+  --select-text-bg-color: var(--color-11);  /* specially set for source mode */
   --search-select-bg-color: var(--color-8);
 
   --side-bar-bg-color: var(--color-main-semitransparent);
@@ -82,6 +83,11 @@ body {
 
 content {
   background: var(--color-3);
+}
+
+/* set default mode's selected color */
+.in-text-selection, ::selection {
+  background-color: var(--color-3);
 }
 
 #write {

--- a/jiaran.css
+++ b/jiaran.css
@@ -14,11 +14,12 @@
   --color-8-trans: #de729285;
   --color-9: #e99eb4;
   --color-10: #fbd3ea85;
+  --color-11: #B5D6FC;
 
   --background-img: url("./jiaran/diana.png");
 
   --control-text-color: #777;
-  --select-text-bg-color: var(--color-3);
+  --select-text-bg-color: var(--color-11);  /* specially set for source mode */
   --search-select-bg-color: var(--color-8);
 
   --side-bar-bg-color: var(--color-main-semitransparent);
@@ -80,6 +81,11 @@ body {
 
 content {
     background: var(--color-3);
+}
+
+/* set default mode's selected color */
+.in-text-selection, ::selection {
+  background-color: var(--color-3);
 }
 
 #write {


### PR DESCRIPTION
## 问题描述

在源代码模式下选中文本时的颜色和背景颜色重合。

## 修复方法

由于在typora原生的base.css和base-control.css中的对于常规模式的文本选中颜色采用
```
.in-text-selection, ::selection {
    background: #B5D6FC;
    text-shadow: none;
    background: var(--select-text-bg-color);
    color: var(--select-text-font-color);
}
```
而源代码区的文本选中颜色采用
```
.CodeMirror-selected, .CodeMirror-selectedtext {
    background: #B5D6FC;
    background: var(--select-text-bg-color)!important;
    color: var(--select-text-font-color)!important;
    text-shadow: none;
}
```
!important的存在使得修改源代码区的背景颜色成为不可能，于是反向思维，将其隔离。

## 效果展示
![image.png](https://i.loli.net/2021/11/09/jmMVhGvwAE5Hugi.png)
![image.png](https://i.loli.net/2021/11/09/ekSliWKj1nyax8q.png)
